### PR TITLE
simple input boxes adding

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,49 +7,59 @@ class App extends Component {
     super(props);
 
     this.state = {
-      inputValue1: '',
-      inputValue2: '',
-      currentMaths: '',
+      inputValue1: null,
+      inputValue2: null,
+      currentMaths: null,
       answer: 0
     }  
-    
+    this.handleChange = this.handleChange.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
+
 }
 
-  handleClick(num) {
-    if (this.state.inputValue1 === '') {
-      this.setState({
-        inputValue1:  num
-      })
-    } else {
-      console.log(num)
-      this.setState({ 
-        inputValue2:  num
-      })
-    }
+handleChange (event) {
+  this.setState({
+    [event.target.name]: event.target.value
     
-    console.log('1..', this.state.inputValue1)
-    console.log('2..',this.state.inputValue2)
-  }
+  })
+}
 
-  handleMaths(maths) {
-    this.setState({
-      currentMaths: maths
-    })
-    console.log('maths', this.state.currentMaths)
-  }
+// handleChange (event) {
+//   this.setState({
+//     [event.target.name]: event.target.value
+//   })
+//   if (this.state.inputValue2) {
+//     this.setState({
+//     answer: (parseInt(this.state.inputValue1) + parseInt(this.state.inputValue2))
+//     })
+//   }
+// }
 
-  handleEquals() {
-    this.setState({
-      answer: this.state.inputValue1 + this.state.inputValue2
-    })
-  }
+handleSubmit(event) {
+  this.setState({
+    answer: (parseInt(this.state.inputValue1) + parseInt(this.state.inputValue2))
+  })
+  event.preventDefault();
+}
+
 
   render() {
     return (
       <div className="App">
-       <button onClick={() => this.handleClick(1)}>1</button>
-       <button onClick={() => this.handleMaths('+')}>+</button>
-       <button onClick={() => this.handleEquals()}>=</button>
+      <form onSubmit={this.handleSubmit}>
+       <label>
+          Input 1
+          <input name="inputValue1" type="text" value={this.state.inputValue1} onChange={this.handleChange} />
+        </label>
+        <label>
+          Input 2
+          <input name="inputValue2" type="text" value={this.state.inputValue2} onChange={this.handleChange} />
+        </label>
+        <input type="submit" value="=" />
+        </form>
+    
+       =
+      
        {this.state.answer}
       </div>
     );


### PR DESCRIPTION
I had issues with setState being asynchronous, I at first was setting state for both input values and answer in the same handleChange event, but the answer wasn't updating at the right time. I then tried to include a conditional (syntax commented out in file) but that yielded the same behaviour. 

The best and quickest work around I could figure out was to include an equals (submit form) button which then sets state for answer. This goes against what you said about keeping it as simple as possible but if I was blocked and this unblocked me, is it not a time saver?

If I was working on a project and was blocked on doing something simple that I knew was going to have to change anyway, and implementing a solution adds a little complexity but is also a feature that is needed anyway (eg, an equals button), is it wise to go ahead with that to save the client money?